### PR TITLE
Feature/test improvements via infection mutations

### DIFF
--- a/.github/workflows/Mutation.yaml
+++ b/.github/workflows/Mutation.yaml
@@ -3,6 +3,8 @@ name: Infection Mutation Testing (Stryker)
 on:
   push:
     branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
 
 jobs:
   build:

--- a/src/Application/App.php
+++ b/src/Application/App.php
@@ -31,12 +31,12 @@ use PinkCrab\Perique\Application\Hooks;
 use PinkCrab\Perique\Services\View\View;
 use PinkCrab\Perique\Application\App_Config;
 use PinkCrab\Perique\Interfaces\DI_Container;
+use PinkCrab\Perique\Application\App_Validation;
 use PinkCrab\Perique\Interfaces\Inject_App_Config;
 use PinkCrab\Perique\Interfaces\Inject_Hook_Loader;
 use PinkCrab\Perique\Interfaces\Inject_DI_Container;
 use PinkCrab\Perique\Interfaces\Registration_Middleware;
 use PinkCrab\Perique\Exceptions\App_Initialization_Exception;
-use PinkCrab\Perique\Tests\Fixtures\DI\Inject_App_Config_Mock;
 use PinkCrab\Perique\Services\Registration\Registration_Service;
 
 final class App {
@@ -47,42 +47,42 @@ final class App {
 	 *
 	 * @var bool
 	 */
-	protected static $booted = false;
+	private static $booted = false;
 
 	/**
 	 * Dependency Injection Container
 	 *
 	 * @var DI_Container
 	 */
-	protected static $container;
+	private static $container;
 
 	/**
 	 * The Apps Config
 	 *
 	 * @var App_Config
 	 */
-	protected static $app_config;
+	private static $app_config;
 
 	/**
 	 * Handles all registration of all Hookable and custom middlewares.
 	 *
 	 * @var Registration_Service
 	 */
-	protected $registration;
+	private $registration;
 
 	/**
 	 * Hook Loader
 	 *
 	 * @var Hook_Loader|null
 	 */
-	protected $loader;
+	private $loader;
 
 	/**
 	 * All middleware that need constructing after finalise has been run.
 	 *
 	 * @var class-string<Registration_Middleware>[]
 	 */
-	protected $middleware_class_names = array();
+	private $middleware_class_names = array();
 
 	/**
 	 * Checks if the app has already been booted.
@@ -265,7 +265,7 @@ final class App {
 	 * @return self
 	 * @throws App_Initialization_Exception (code 9)
 	 */
-	protected function finalise(): self {
+	private function finalise(): self {
 
 		// Bind self to container.
 		self::$container->addRule(
@@ -308,7 +308,7 @@ final class App {
 			)
 		);
 
-		// Allow the passing of App Config via interface and method injection.
+		//Allow the passing of App Config via interface and method injection.
 		self::$container->addRule(
 			Inject_App_Config::class,
 			array(

--- a/src/Application/App_Validation.php
+++ b/src/Application/App_Validation.php
@@ -17,7 +17,7 @@ use PinkCrab\Perique\Application\App;
 use Reflection;
 use ReflectionProperty;
 
-class App_Validation {
+final class App_Validation {
 
 	/** @var string */
 	public const ERROR_MESSAGE_TEMPLATE = '%s was not set in App';
@@ -30,7 +30,7 @@ class App_Validation {
 	 *
 	 * @var array<string,bool>
 	 */
-	protected $required_properties = array(
+	private $required_properties = array(
 		'container'    => true,
 		'app_config'   => true,
 		'registration' => false,
@@ -41,7 +41,7 @@ class App_Validation {
 	public $errors = array();
 
 	/** @var App */
-	protected $app;
+	private $app;
 
 	public function __construct( App $app ) {
 		$this->app = $app;
@@ -64,7 +64,7 @@ class App_Validation {
 	 *
 	 * @return void
 	 */
-	protected function validate_properties_set(): void {
+	private function validate_properties_set(): void {
 		foreach ( $this->required_properties as $property => $is_static ) {
 			$property_reflection = new ReflectionProperty( $this->app, $property );
 			$property_reflection->setAccessible( true );
@@ -79,7 +79,7 @@ class App_Validation {
 	 *
 	 * @return void
 	 */
-	protected function already_booted(): void {
+	private function already_booted(): void {
 		if ( $this->app->is_booted() === true ) {
 			$this->errors[] = self::ERROR_MESSAGE_APP_BOOTED;
 		}

--- a/tests/Application/Test_App_Config.php
+++ b/tests/Application/Test_App_Config.php
@@ -353,7 +353,6 @@ class Test_App_Config extends WP_UnitTestCase {
 
 		$app_config = new App_Config();
 		$defaults   = $app_config->export_settings();
-		dump( $defaults );
 
 		// Check paths.
 		$this->assertEquals( $base_path, $defaults['path']['plugin'] );

--- a/tests/Application/Test_Di_Container_Injectables.php
+++ b/tests/Application/Test_Di_Container_Injectables.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace PinkCrab\Perique\Tests\Application;
 
 use WP_UnitTestCase;
+use Gin0115\WPUnit_Helpers\Objects;
+use PinkCrab\Perique\Application\App_Config;
 use PinkCrab\Perique\Tests\Application\App_Helper_Trait;
 use PinkCrab\Perique\Tests\Fixtures\DI\Inject_App_Config_Mock;
 use PinkCrab\Perique\Tests\Fixtures\DI\Inject_Hook_Loader_Mock;
@@ -38,6 +40,9 @@ class Test_Di_Container_Injectables extends WP_UnitTestCase {
 
 		$mock = $app::make( Inject_DI_Container_Mock::class );
 		$this->assertTrue( $mock->has_container() );
+
+		// Check the container is the same as the app.
+		$this->assertSame( $app->__debugInfo()[ 'container' ], $mock->get_container() );
 	}
 
 	/** @testdox It should be possible to pass the Hook Loader to a dependency using an interface. */
@@ -48,9 +53,12 @@ class Test_Di_Container_Injectables extends WP_UnitTestCase {
 
 		$mock = $app::make( Inject_Hook_Loader_Mock::class );
 		$this->assertTrue( $mock->has_loader() );
+
+		$loader = Objects::get_property( $app, 'loader' );
+		$this->assertSame( $loader, $mock->get_loader() );
 	}
 
-    /** @testdox It should be possible to pass theApp Config to a dependency using an interface. */
+	/** @testdox It should be possible to pass theApp Config to a dependency using an interface. */
 	public function test_inject_app_config(): void {
 		// Populate the APP
 		$app = $this->pre_populated_app_provider()->boot();
@@ -58,5 +66,8 @@ class Test_Di_Container_Injectables extends WP_UnitTestCase {
 
 		$mock = $app::make( Inject_App_Config_Mock::class );
 		$this->assertTrue( $mock->has_app_config() );
+
+		// Check the config is the same as the app.
+		$this->assertSame( $app->__debugInfo()[ 'app_config' ], $mock->get_app_config() );
 	}
 }

--- a/tests/Fixtures/DI/Inject_App_Config_Mock.php
+++ b/tests/Fixtures/DI/Inject_App_Config_Mock.php
@@ -27,4 +27,13 @@ class Inject_App_Config_Mock implements Inject_App_Config {
 	public function has_app_config(): bool {
 		return null !== $this->app_config;
 	}
+
+	/**
+	 * Get the app config instance.
+	 * 
+	 * @return \PinkCrab\Perique\Application\App_Config
+	 */
+	public function get_app_config(): \PinkCrab\Perique\Application\App_Config {
+		return $this->app_config;
+	}
 }

--- a/tests/Fixtures/DI/Inject_DI_Container_Mock.php
+++ b/tests/Fixtures/DI/Inject_DI_Container_Mock.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace PinkCrab\Perique\Tests\Fixtures\DI;
 
+use PinkCrab\Perique\Interfaces\DI_Container;
 use PinkCrab\Perique\Interfaces\Inject_DI_Container;
 use PinkCrab\Perique\Services\Container_Aware_Traits\Inject_DI_Container_Aware;
 
@@ -26,5 +27,14 @@ class Inject_DI_Container_Mock implements Inject_DI_Container {
 	 */
 	public function has_container(): bool {
 		return null !== $this->di_container;
+	}
+
+	/**
+	 * Get the container instance.
+	 *
+	 * @return \PinkCrab\Perique\Services\DI_Container
+	 */
+	public function get_container(): DI_Container {
+		return $this->di_container;
 	}
 }

--- a/tests/Fixtures/DI/Inject_Hook_Loader_Mock.php
+++ b/tests/Fixtures/DI/Inject_Hook_Loader_Mock.php
@@ -27,4 +27,13 @@ class Inject_Hook_Loader_Mock implements Inject_Hook_Loader {
 	public function has_loader(): bool {
 		return null !== $this->loader;
 	}
+
+	/**
+	 * Get the loader instance.
+	 *
+	 * @return \PinkCrab\Loader\Hook_Loader
+	 */
+	public function get_loader(): \PinkCrab\Loader\Hook_Loader {
+		return $this->loader;
+	}
 }


### PR DESCRIPTION
 Makes all protected properties/methods in App_Validator private and class as final. (Not possible to really overwrite)
Makes all protected properties/methods in App private, as class is marked as final
Adds a few getter methods to the mock DI, Config & Loader classes, this allows for testing that the parameters are passed as expected and you do have access the instances used by the app. Tests are also added for this too. 