### PR TITLE
ensure min 1.1 is used for psr/container, add type hints to WP_Dice w…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": ">=7.2.0",
         "level-2/dice": "4.0.*",
-        "psr/container": "^1.0",
+        "psr/container": "^1.1",
         "pinkcrab/hook-loader": "^1.1"
     },
     "scripts": {

--- a/src/Services/Dice/PinkCrab_Dice.php
+++ b/src/Services/Dice/PinkCrab_Dice.php
@@ -64,7 +64,7 @@ class PinkCrab_Dice implements DI_Container {
 	 * @param string $id Class name (fully namespaced.)
 	 * @return object|null
 	 */
-	public function get( $id ) {
+	public function get( string $id ) {
 		if ( ! $this->has( $id ) ) {
 			throw new DI_Container_Exception( "{$id} not defined in container", 1 );
 		}
@@ -78,7 +78,7 @@ class PinkCrab_Dice implements DI_Container {
 	 * @param string $id Class name (fully namespaced.)
 	 * @return bool
 	 */
-	public function has( $id ) {
+	public function has( string $id ): bool {
 		$from_dice = $this->dice->getRule( $id );
 		// If set in global rules.
 		if ( array_key_exists( 'substitutions', $from_dice )


### PR DESCRIPTION
…rapper

Set min verison of PSR/Container to 1.1
Add type hints to WP_Dice (not thanks to container 1.1 as min, from dropping php7.1 support)