### PR TITLE
The base component path is now set as {view_path}/compoents, unit tes…

### DIFF
--- a/src/Application/App_Factory.php
+++ b/src/Application/App_Factory.php
@@ -24,6 +24,7 @@ use PinkCrab\Perique\Utils\App_Config_Path_Helper;
 use PinkCrab\Perique\Interfaces\Registration_Middleware;
 use PinkCrab\Perique\Services\Registration\Module_Manager;
 use PinkCrab\Perique\Services\Registration\Registration_Service;
+use PinkCrab\Perique\Services\View\Component\Component_Compiler;
 use PinkCrab\Perique\Services\Registration\Modules\Hookable_Module;
 
 class App_Factory {
@@ -197,14 +198,17 @@ class App_Factory {
 	 */
 	protected function default_di_rules(): array {
 		return array(
-			PHP_Engine::class => array(
+			PHP_Engine::class         => array(
 				'constructParams' => array(
 					$this->get_base_view_path(),
 				),
 			),
-			Renderable::class => array(
+			Renderable::class         => array(
 				'instanceOf' => PHP_Engine::class,
 				'shared'     => true,
+			),
+			Component_Compiler::class => array(
+				'constructParams' => array( 'components' ),
 			),
 		);
 	}

--- a/src/Services/View/PHP_Engine.php
+++ b/src/Services/View/PHP_Engine.php
@@ -99,7 +99,7 @@ final class PHP_Engine implements Renderable {
 		// Compile the component.
 		$compiled = $this->component_compiler->compile( $component );
 		$template = $this->maybe_resolve_dot_notation( $compiled->template() );
-		$view     = sprintf( '%s%s.php', \DIRECTORY_SEPARATOR, trim( $template ) );
+		$view     = sprintf( '%s%s%s.php', $this->base_view_path, \DIRECTORY_SEPARATOR, trim( $template ) );
 		if ( $print ) {
 			print( $this->render_buffer( $view, $compiled->data() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {

--- a/tests/Fixtures/views/render-component.php
+++ b/tests/Fixtures/views/render-component.php
@@ -1,0 +1,2 @@
+<?php 
+$this->component($component);

--- a/tests/Integration/Application/Test_App.php
+++ b/tests/Integration/Application/Test_App.php
@@ -49,8 +49,7 @@ class Test_App extends WP_UnitTestCase {
 		self::unset_app_instance();
 	}
 
-	public function set_up()
-	{
+	public function set_up() {
 		parent::set_up();
 		self::unset_app_instance();
 	}
@@ -181,7 +180,7 @@ class Test_App extends WP_UnitTestCase {
 		$app->module( Module_With_Middleware__Module::class );
 
 		// Module should be constructed and added to the module manager.
-		$manager_from_app = Objects::get_property( $app, 'module_manager' );
+		$manager_from_app      = Objects::get_property( $app, 'module_manager' );
 		$registration_from_app = Objects::get_property( $manager_from_app, 'registration_service' );
 		$middleware            = Objects::get_property( $registration_from_app, 'middleware' );
 		$this->assertCount( 1, $middleware );
@@ -213,10 +212,9 @@ class Test_App extends WP_UnitTestCase {
 		$app->module( Module_With_Middleware__Module::class );
 		$app->registration_classes( array( Sample_Class::class ) );
 
-		$mm = Objects::get_property( $app, 'module_manager' );
+		$mm           = Objects::get_property( $app, 'module_manager' );
 		$registration = Objects::get_property( $mm, 'registration_service' );
-		
-		
+
 		$this->assertContains( Sample_Class::class, Objects::get_property( $registration, 'class_list' ) );
 	}
 
@@ -317,16 +315,16 @@ class Test_App extends WP_UnitTestCase {
 	public function test_view_path_and_app_not_set_if_custom_view_path_defined(): void {
 		$app = new App( \FIXTURES_PATH );
 		$app->set_view_path( 'custom/path' );
-		$app->set_app_config([]);
+		$app->set_app_config( array() );
 
 		$config = $app->__debugInfo()['app_config'];
 
 		// Paths
-		$this->assertEquals(\FIXTURES_PATH . '/', $config->path('plugin'));
-		$this->assertEquals('custom/path/', $config->path('view'));
-		
+		$this->assertEquals( \FIXTURES_PATH . '/', $config->path( 'plugin' ) );
+		$this->assertEquals( 'custom/path/', $config->path( 'view' ) );
+
 		// URLs
-		$this->assertEquals('http://example.org/wp-content/plugins/Fixtures/', $config->url('plugin'));
-		$this->assertEquals('http://example.org/wp-content/plugins/Fixtures/custom/path/', $config->url('view'));
+		$this->assertEquals( 'http://example.org/wp-content/plugins/Fixtures/', $config->url( 'plugin' ) );
+		$this->assertEquals( 'http://example.org/wp-content/plugins/Fixtures/custom/path/', $config->url( 'view' ) );
 	}
 }

--- a/tests/Integration/View/Test_Use_View.php
+++ b/tests/Integration/View/Test_Use_View.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Using the View Service
+ *
+ * @since 2.0.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Perique
+ */
+
+namespace PinkCrab\Perique\Tests\Registration;
+
+use WP_UnitTestCase;
+use PinkCrab\Loader\Hook_Loader;
+use PinkCrab\Perique\Application\App_Factory;
+use PinkCrab\Perique\Interfaces\DI_Container;
+use PinkCrab\Perique\Services\Dice\PinkCrab_Dice;
+use PinkCrab\Perique\Tests\Application\App_Helper_Trait;
+use PinkCrab\Perique\Exceptions\Module_Manager_Exception;
+use PinkCrab\Perique\Services\Registration\Module_Manager;
+use PinkCrab\Perique\Tests\Fixtures\Mock_Objects\Sample_Class;
+use PinkCrab\Perique\Services\Registration\Registration_Service;
+use PinkCrab\Perique\Tests\Fixtures\Mock_Objects\View_Components\Span;
+use PinkCrab\Perique\Tests\Fixtures\Mock_Objects\View_Components\P_Tag_Component;
+use PinkCrab\Perique\Tests\Fixtures\Modules\Invalid\With_Invalid_Class_Middleware;
+use PinkCrab\Perique\Tests\Fixtures\Modules\With_Middleware\Module_With_Middleware__Module;
+use PinkCrab\Perique\Tests\Fixtures\Modules\With_Middleware\Module_With_Middleware__Middleware;
+use PinkCrab\Perique\Tests\Fixtures\Modules\Without_Middleware\Module_Without_Middleware__Module;
+
+/**
+ * @group integration
+ * @group view
+ * @group components
+ *
+ */
+class Test_Use_View extends WP_UnitTestCase {
+
+
+	/**
+	 * @method self::unset_app_instance();
+	 */
+	use App_Helper_Trait;
+
+	public function tear_down(): void {
+		parent::tear_down();
+		self::unset_app_instance();
+
+	}
+
+	public function set_up() {
+		parent::set_up();
+		self::unset_app_instance();
+	}
+
+	/** @testdox By default the default component path should be {view_path}/component */
+	public function test_render_component_with_base_path() {
+		$app = ( new App_Factory( \FIXTURES_PATH ) )
+			->default_setup()
+			->boot();
+
+		$output = $app::view()->render(
+			'render-component',
+			array( 'component' => new P_Tag_Component( 'test', new Span( 'span-class', 'span-content' ) ) ),
+			false
+		);
+		$this->assertEquals('<p class="test"><span class="span-class">span-content</span></p>', $output);
+	}
+}

--- a/tests/Unit/View/Test_Components.php
+++ b/tests/Unit/View/Test_Components.php
@@ -36,7 +36,7 @@ class Test_Components extends \WP_UnitTestCase {
 	private static $php_engine;
 
 	public static function setUpBeforeClass(): void {
-		self::$component_path = FIXTURES_PATH . '/views/components/';
+		self::$component_path = 'components/';
 		self::$php_engine     = new PHP_Engine( FIXTURES_PATH . '/views/' );
 	}
 
@@ -179,4 +179,6 @@ class Test_Components extends \WP_UnitTestCase {
 		$this->expectOutputString( 'dot--not--ation--aa');
 		$view->component( new Input( 'dot', 'not', 'ation', 'aa' ), true );
 	}
+
+	
 }


### PR DESCRIPTION
…t adjusted to reflect and added a single application test to check rendering with cub components via view service