### PR TITLE
remove the attempt to resolve dot nations in base view paths and remo…

### DIFF
--- a/src/Services/View/PHP_Engine.php
+++ b/src/Services/View/PHP_Engine.php
@@ -217,7 +217,6 @@ final class PHP_Engine implements Renderable {
 	 * @throws Exception
 	 */
 	private function verify_view_path( string $path ): string {
-		$path = $this->maybe_resolve_dot_notation( $path );
 		$path = rtrim( $path, '/' ) . '/';
 
 		if ( ! \is_dir( $path ) ) {

--- a/tests/Unit/View/Test_PHP_Engine.php
+++ b/tests/Unit/View/Test_PHP_Engine.php
@@ -38,7 +38,7 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() : void {
+	public function setUp(): void {
 		parent::setUp();
 		$this->view = new PHP_Engine( FIXTURES_PATH . '/views/' );
 	}
@@ -164,7 +164,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		$view->render( '/hello.php', array( 'hello' => 'Hello World' ) );
 	}
 
-	/** @testdox An exception should be thrown if the engine attempts to render a component with setting the compiler. */
+	/**
+ * @testdox An exception should be thrown if the engine attempts to render a component with setting the compiler.
+*/
 	public function test_throws_exception_if_component_not_set(): void {
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'No component compiler passed to PHP_Engine' );
@@ -191,20 +193,12 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox It should be possible to define the base path for view using dot notation. */
-	public function test_can_set_base_path_using_dot_notation(): void {
-		$this->expectOutputString( 'foo' );
-		$view = new PHP_Engine( \dirname( __DIR__, 2 ) . '.Fixtures.views.' );
-		$view->render(
-			'sub_path.template',
-			array( 'variable' => 'foo' ),
-			View::PRINT_VIEW // Optional as print view is default.
-		);
-	}
 
-	/** @testdox It should be possible to use filepaths with or without the .php extensions */
+	/**
+ * @testdox It should be possible to use filepaths with or without the .php extensions
+*/
 	public function test_can_render_path_with_or_without_php_extension(): void {
-		function() {
+		function () {
 			$this->expectOutputString( 'foo' );
 			$this->view->render(
 				'sub_path.template',
@@ -221,7 +215,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox It should be possible to access the base_path from the engine. */
+	/**
+ * @testdox It should be possible to access the base_path from the engine.
+*/
 	public function test_can_get_base_path(): void {
 		$path = FIXTURES_PATH . '/views/';
 		$this->assertEquals(
@@ -230,7 +226,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox By default view_models should be printed, unless false is passed as the param for $print */
+	/**
+ * @testdox By default view_models should be printed, unless false is passed as the param for $print
+*/
 	public function test_view_models_print_by_default(): void {
 		$this->expectOutputString( 'partial_value' );
 		$this->view->view_model(
@@ -241,7 +239,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox By default the partial() method should print the view, unless false is passed as the param for $prinr */
+	/**
+ * @testdox By default the partial() method should print the view, unless false is passed as the param for $prinr
+*/
 	public function test_returns_partial_from_template(): void {
 		$this->expectOutputString( 'rendered partial using PHPEngine->partial()' );
 		$this->view->partial(
@@ -250,11 +250,11 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox Any path passed as a view, should be trimmed for all whitespace. */
+	/**
+ * @testdox Any path passed as a view, should be trimmed for all whitespace.
+*/
 	public function test_view_path_is_trimmed(): void {
 		$this->expectOutputString( 'Hello World' );
 		$this->view->render( ' hello ', array( 'hello' => 'Hello World' ) );
 	}
-
-
 }


### PR DESCRIPTION
…ved matching test

This pull request primarily cleans up the unit tests for the `PHP_Engine` class by improving the formatting of test docblocks, and removes an obsolete test related to dot notation for base paths. Additionally, it updates the implementation to no longer resolve dot notation in view paths.

Test improvements and cleanup:

* Reformatted all test docblocks in `tests/Unit/View/Test_PHP_Engine.php` to use standard PHPDoc block comments for better readability and consistency. [[1]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L167-R169) [[2]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L194-R199) [[3]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L224-R220) [[4]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L233-R231) [[5]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L244-R244) [[6]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L253-L259)
* Removed the test `test_can_set_base_path_using_dot_notation`, which checked for using dot notation in base paths, indicating this feature is no longer supported or necessary.

Implementation change:

* Removed the call to `maybe_resolve_dot_notation` in the `verify_view_path` method of `src/Services/View/PHP_Engine.php`, so dot notation is no longer resolved in view paths.