### PR TITLE
Release/2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ http://www.opensource.org/licenses/mit-license.html
 
 ## Change Log ##
 
+* 2.1.1 - Remove the attempt to resolve dot notation in the base view path of the PHP_Engine, as this was causing issues when servers have . in folder names.
 * 2.1.0 - Updated to WP6.6, changed PHPCS rules and added a number of new helpers to App_Config.
    * App_Config::asset_url() - Returns the full URL to an asset.
    * App_Config::asset_path() - Returns the full path to an asset.

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require": {
         "php": ">=7.4.0",
         "gin0115/dice": "4.1.*",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "pinkcrab/hook-loader": "^1.1",
         "pinkcrab/function-constructors": "0.2.*"
     },

--- a/src/Services/View/PHP_Engine.php
+++ b/src/Services/View/PHP_Engine.php
@@ -217,7 +217,6 @@ final class PHP_Engine implements Renderable {
 	 * @throws Exception
 	 */
 	private function verify_view_path( string $path ): string {
-		$path = $this->maybe_resolve_dot_notation( $path );
 		$path = rtrim( $path, '/' ) . '/';
 
 		if ( ! \is_dir( $path ) ) {

--- a/tests/Unit/View/Test_PHP_Engine.php
+++ b/tests/Unit/View/Test_PHP_Engine.php
@@ -38,7 +38,7 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() : void {
+	public function setUp(): void {
 		parent::setUp();
 		$this->view = new PHP_Engine( FIXTURES_PATH . '/views/' );
 	}
@@ -164,7 +164,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		$view->render( '/hello.php', array( 'hello' => 'Hello World' ) );
 	}
 
-	/** @testdox An exception should be thrown if the engine attempts to render a component with setting the compiler. */
+	/**
+ * @testdox An exception should be thrown if the engine attempts to render a component with setting the compiler.
+*/
 	public function test_throws_exception_if_component_not_set(): void {
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'No component compiler passed to PHP_Engine' );
@@ -191,20 +193,12 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox It should be possible to define the base path for view using dot notation. */
-	public function test_can_set_base_path_using_dot_notation(): void {
-		$this->expectOutputString( 'foo' );
-		$view = new PHP_Engine( \dirname( __DIR__, 2 ) . '.Fixtures.views.' );
-		$view->render(
-			'sub_path.template',
-			array( 'variable' => 'foo' ),
-			View::PRINT_VIEW // Optional as print view is default.
-		);
-	}
 
-	/** @testdox It should be possible to use filepaths with or without the .php extensions */
+	/**
+ * @testdox It should be possible to use filepaths with or without the .php extensions
+*/
 	public function test_can_render_path_with_or_without_php_extension(): void {
-		function() {
+		function () {
 			$this->expectOutputString( 'foo' );
 			$this->view->render(
 				'sub_path.template',
@@ -221,7 +215,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox It should be possible to access the base_path from the engine. */
+	/**
+ * @testdox It should be possible to access the base_path from the engine.
+*/
 	public function test_can_get_base_path(): void {
 		$path = FIXTURES_PATH . '/views/';
 		$this->assertEquals(
@@ -230,7 +226,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox By default view_models should be printed, unless false is passed as the param for $print */
+	/**
+ * @testdox By default view_models should be printed, unless false is passed as the param for $print
+*/
 	public function test_view_models_print_by_default(): void {
 		$this->expectOutputString( 'partial_value' );
 		$this->view->view_model(
@@ -241,7 +239,9 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox By default the partial() method should print the view, unless false is passed as the param for $prinr */
+	/**
+ * @testdox By default the partial() method should print the view, unless false is passed as the param for $prinr
+*/
 	public function test_returns_partial_from_template(): void {
 		$this->expectOutputString( 'rendered partial using PHPEngine->partial()' );
 		$this->view->partial(
@@ -250,11 +250,11 @@ class Test_PHP_Engine extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox Any path passed as a view, should be trimmed for all whitespace. */
+	/**
+ * @testdox Any path passed as a view, should be trimmed for all whitespace.
+*/
 	public function test_view_path_is_trimmed(): void {
 		$this->expectOutputString( 'Hello World' );
 		$this->view->render( ' hello ', array( 'hello' => 'Hello World' ) );
 	}
-
-
 }


### PR DESCRIPTION
This pull request focuses on improving compatibility and reliability in the view rendering engine, particularly around path handling and dependency versions. The most important changes are the removal of dot notation resolution in view paths, updates to dependency requirements, and cleanup of related tests.

**View Path Handling:**

* Removed the logic that attempted to resolve dot notation in the base view path of the `PHP_Engine`, as it caused issues when server folder names contained dots. This also removes the associated test for setting the base path using dot notation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R366) [[2]](diffhunk://#diff-c78d27ac11377d22c5deea73004656a9746e896a7abd144cdf41f00f903442e4L220) [[3]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L194-R199)

**Dependency Updates:**

* Updated the `psr/container` requirement in `composer.json` to allow both v1 and v2, improving compatibility with other packages.

**Test Suite Cleanup:**

* Refactored docblocks in `Test_PHP_Engine.php` for consistency and readability, and removed the test related to dot notation in base paths. [[1]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L167-R169) [[2]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L194-R199) [[3]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L224-R220) [[4]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L233-R231) [[5]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L244-R244) [[6]](diffhunk://#diff-1ecf04149ba0956aad8dc1dea5b6eec4d44d185eccbf4ff4351862de87b60344L253-L259)